### PR TITLE
getActive() false positives fix

### DIFF
--- a/menus/models/Menus_NodeModel.php
+++ b/menus/models/Menus_NodeModel.php
@@ -131,18 +131,16 @@ class Menus_NodeModel extends BaseElementModel
     $currentUrl = craft()->request->getUrl();
     $linkUrl = $this->getUrl();
 
-    if ($linkUrl != null )
-    {
-      if (strpos($currentUrl,$this->getLink()) !== false)
-      {
-
-        return true;
-
+    if ($currentUrl == $linkUrl){ //This just matches the home page
+      return true;
+    } else{
+      //This will match anything else, including custom index single pages
+      if(strpos($currentUrl, $linkUrl) !== false && $linkUrl !== '/'){
+          return true;
       }
-
     }
-
     return false;
+  }
 
 
   }


### PR DESCRIPTION
Made this change due to false positives I was getting on my project where homepage was always set to active.

![screen shot 2015-10-01 at 11 10 44 pm](https://cloud.githubusercontent.com/assets/7657062/10233918/b3ac9f42-6891-11e5-89d8-ae8a5bb5a635.png)

This issue occurs when you land on the index page of channels and you are using a single as the custom index.
With the quick fix, you will no longer get false positive on homepage and will no longer show as active regardless of where you are in the site in the menu.

![screen shot 2015-10-01 at 11 11 26 pm](https://cloud.githubusercontent.com/assets/7657062/10233959/dca95ae8-6891-11e5-878e-0786c534a08c.png)

It is a quick fix for now, if you like, I can create a more comprehensive fix that will cover all the bases, just let me know.
