### PR TITLE
Option to assign nodes to be opened in a new window

### DIFF
--- a/menus/MenusPlugin.php
+++ b/menus/MenusPlugin.php
@@ -12,7 +12,7 @@ class MenusPlugin extends BasePlugin
 
   function getVersion()
   {
-    return '0.9';
+    return '0.91';
   }
 
   function getDeveloper()

--- a/menus/controllers/Menus_NodesController.php
+++ b/menus/controllers/Menus_NodesController.php
@@ -175,6 +175,7 @@ class Menus_NodesController extends BaseController
 
     $node->customUrl      = craft()->request->getPost('customUrl', $node->customUrl );
     $node->getContent()->title = craft()->request->getPost('title', $node->title);
+    $node->newWindow = craft()->request->getPost('newWindow');
 
     // Parent
     $parentId = craft()->request->getPost('parentId');

--- a/menus/elementtypes/Menus_NodeElementType.php
+++ b/menus/elementtypes/Menus_NodeElementType.php
@@ -98,7 +98,8 @@ class Menus_NodeElementType extends BaseElementType
       return array(
       'title'     => Craft::t('Title'),
       'link'     => Craft::t('Link'),
-      //'url'     => Craft::t('Url'),
+      'newWindow' => Craft::t('New Window'),
+    //   'url'     => Craft::t('Url'),
       );
     }
 
@@ -113,7 +114,13 @@ class Menus_NodeElementType extends BaseElementType
     {
       switch ($attribute)
       {
+        case 'newWindow':
+            if($element->newWindow == 1) {
+                return 'Yes';
+            }
 
+            return 'No';
+        break;
         default:
         {
           return parent::getTableAttributeHtml($element, $attribute);
@@ -145,7 +152,7 @@ class Menus_NodeElementType extends BaseElementType
     public function modifyElementsQuery(DbCommand $query, ElementCriteriaModel $criteria)
     {
       $query
-      ->addSelect('nodes.menuId, nodes.linkedEntryId, nodes.customUrl, i18n.uri linkedEntryUrl')
+      ->addSelect('nodes.menuId, nodes.linkedEntryId, nodes.customUrl, nodes.newWindow, i18n.uri linkedEntryUrl')
       ->join('menus_nodes nodes', 'nodes.id = elements.id')
       ->join('menus menus', 'menus.id = nodes.menuId')
       ->leftJoin('elements_i18n i18n', 'i18n.elementId = nodes.linkedEntryId')

--- a/menus/migrations/m160725_152400_menus_addNweWindowColumn.php
+++ b/menus/migrations/m160725_152400_menus_addNweWindowColumn.php
@@ -1,0 +1,15 @@
+<?php
+namespace Craft;
+
+class m160725_152400_menus_addNweWindowColumn extends BaseMigration
+{
+    public function safeUp()
+    {
+        return parent::addColumn('menus_nodes', 'newWindow', 'TINYINT');
+    }
+
+    public function safeDown()
+    {
+        return parent::dropColumn('menus_nodes', 'newWindow');
+    }
+}

--- a/menus/models/Menus_NodeModel.php
+++ b/menus/models/Menus_NodeModel.php
@@ -19,6 +19,7 @@ class Menus_NodeModel extends BaseElementModel
       'linkedEntryId'  => AttributeType::Number,
       'customUrl'  => AttributeType::String,
       'linkedEntryUrl'  => AttributeType::String,
+      'newWindow'  => AttributeType::Bool,
 
       // Just used for saving categories
       'newParentId'      => AttributeType::Number

--- a/menus/records/Menus_NodeRecord.php
+++ b/menus/records/Menus_NodeRecord.php
@@ -22,7 +22,8 @@ class Menus_NodeRecord extends BaseRecord
   {
     return array(
       'linkedEntryId' => array(AttributeType::Number, 'required' => false),
-      'customUrl'   => array(AttributeType::String, 'required' => false)
+      'customUrl'   => array(AttributeType::String, 'required' => false),
+      'newWindow'   => array(AttributeType::Bool, 'required' => false)
     );
   }
 
@@ -35,7 +36,6 @@ class Menus_NodeRecord extends BaseRecord
       'element'  => array(static::BELONGS_TO, 'ElementRecord', 'id', 'required' => true, 'onDelete' => static::CASCADE),
       'menu' => array(static::BELONGS_TO, 'Menus_MenuRecord', 'required' => true, 'onDelete' => static::CASCADE),
       'linkedEntry' => array(static::HAS_ONE, 'EntryRecord', 'linkedEntryId','required' => false),
-
     );
   }
 }

--- a/menus/services/Menus_NodesService.php
+++ b/menus/services/Menus_NodesService.php
@@ -69,6 +69,7 @@ class Menus_NodesService extends BaseApplicationComponent
     $nodeRecord->menuId = $node->menuId;
     $nodeRecord->linkedEntryId  = $node->linkedEntryId;
     $nodeRecord->customUrl    = $node->customUrl;
+    $nodeRecord->newWindow    = $node->newWindow;
 
     $nodeRecord->validate();
     $node->addErrors($nodeRecord->getErrors());

--- a/menus/templates/_edit.html
+++ b/menus/templates/_edit.html
@@ -48,6 +48,17 @@
           autofocus: true,
           required: false
         }) }}
+
+        {{ forms.checkBox({
+          label: "Open in New Window"|t,
+          id: 'newWindow',
+          name: 'newWindow',
+          checked: node.newWindow,
+          errors: node.getErrors('newWindow'),
+          first: true,
+          autofocus: true,
+          required: false
+        }) }}
       </div>
     </div> <!--/item-->
 

--- a/menus/templates/settings.html
+++ b/menus/templates/settings.html
@@ -1,18 +1,5 @@
 {% import "_includes/forms" as forms %}
 
-{% set hideSave %}
-.buttons {
-  display:none;
-}
-
-#settings-newmenucontainer.buttons {
-  display:block;
-}
-{% endset %}
-
-{% includeCss hideSave %}
-
-
 <div id="nomenus"{% if menus %} class="hidden"{% endif %}>
   <p>{{ "No menus exist yet."|t }}</p>
 </div>


### PR DESCRIPTION
- Added a new checkbox on the edit form to define if a node should open in a new window
- Added column on index to show the option for each node
- Added migration script for new DB column

Syntax example for the front-end: `{{ node.newWindow ? 'target="_blank"' }}`
