### PR TITLE
[ui] Remove unnecessary code that hides all items with a class of .buttons

### DIFF
--- a/menus/models/Menus_NodeModel.php
+++ b/menus/models/Menus_NodeModel.php
@@ -120,6 +120,29 @@ class Menus_NodeModel extends BaseElementModel
   }
 
   /**
+  * Returns the entry of a node
+  * {{ node.entry.fieldHandle }}
+  *
+  * @return String|null
+  */
+  public function getEntry()
+  {
+    if ($this->linkedEntryId)
+    {
+      $entry = craft()->entries->getEntryById($this->linkedEntryId);
+      if ($entry != null) {
+        return $entry;
+      } else {
+        return null;
+      }
+    }
+    else
+    {
+      return null;
+    }
+  }
+
+  /**
   * Returns the nodes active state
   *
   * @return String|null

--- a/menus/templates/settings.html
+++ b/menus/templates/settings.html
@@ -1,18 +1,5 @@
 {% import "_includes/forms" as forms %}
 
-{% set hideSave %}
-.buttons {
-  display:none;
-}
-
-#settings-newmenucontainer.buttons {
-  display:block;
-}
-{% endset %}
-
-{% includeCss hideSave %}
-
-
 <div id="nomenus"{% if menus %} class="hidden"{% endif %}>
   <p>{{ "No menus exist yet."|t }}</p>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Each node has the following properties
 * node.url (full url)
 * node.active (returns true if the node or a childnode matches the current url)
 * node.children (any child nodes)
+* node.entry (returns entire node's entry and all attached fields)
 
 
 


### PR DESCRIPTION
This plugin includes unspecific CSS markup that hides all items with a class of .buttons, without regard to any other elements using that class:

![screen shot 2016-09-07 at 8 28 27 pm](https://cloud.githubusercontent.com/assets/1667106/18333063/bb8de562-7539-11e6-94ef-a94aee8ad9bd.png)

This PR removes that code, without any adverse affect to the plugin itself:

![screen shot 2016-09-07 at 8 27 59 pm](https://cloud.githubusercontent.com/assets/1667106/18333066/cf7ebc54-7539-11e6-98dc-4320e8d4ec64.png)
